### PR TITLE
feat: allow user templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "url": "https://github.com/Kibibit/announce-it/issues"
   },
   "homepage": "https://github.com/Kibibit/announce-it#readme",
+  "announcements": {
+    "tweet": "Version <%= version %> of <%= package %> is live! check it out <%=homepage %>"
+  },
   "release": {
     "branches": [
       "master",
@@ -68,7 +71,8 @@
   "dependencies": {
     "dotenv": "^7.0.0",
     "find-root": "^1.1.0",
-    "twitter-lite": "^0.9.4",
-    "fs-extra": "^7.0.1"
+    "fs-extra": "^7.0.1",
+    "lodash": "^4.17.11",
+    "twitter-lite": "^0.9.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,10 @@ import Twitter from 'twitter-lite';
 import fs from 'fs-extra';
 import findRoot from 'find-root';
 import dotenv from 'dotenv';
+import { template } from 'lodash';
 
 dotenv.config();
 const root = findRoot(process.cwd());
-
-
 
 const client = new Twitter({
   subdomain: "api",
@@ -20,9 +19,7 @@ const client = new Twitter({
 client
   .get('account/verify_credentials')
     .then(() => fs.readJson(`${root}/package.json`, 'utf8'))
-    .then((packageData) => {
-      return `Version ${packageData.version} of ${packageData.name} is out!`;
-    })
+    .then((packageData) => getTweet(packageData))
     .then((tweet) => {
       client.post('statuses/update', {status: tweet})
       return tweet;
@@ -30,3 +27,14 @@ client
     .then((tweet) => console.log('Tweeted:', tweet))
     .catch(console.error);
     
+function getTweet(packageData) {
+  const tweetTemplate = template(packageData.announcements.tweet);
+
+  return tweetTemplate({
+    package: packageData.name,
+    version: packageData.version,
+    description: packageData.description,
+    author: packageData.author,
+    homepage: packageData.homepage
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const client = new Twitter({
 client
   .get('account/verify_credentials')
     .then(() => fs.readJson(`${root}/package.json`, 'utf8'))
-    .then((packageData) => getTweet(packageData))
+    .then((packageData) => generateTweet(packageData))
     .then((tweet) => {
       client.post('statuses/update', {status: tweet})
       return tweet;
@@ -27,7 +27,7 @@ client
     .then((tweet) => console.log('Tweeted:', tweet))
     .catch(console.error);
     
-function getTweet(packageData) {
+function generateTweet(packageData) {
   const tweetTemplate = template(packageData.announcements.tweet);
 
   return tweetTemplate({


### PR DESCRIPTION
## Feature: User Templates
* Users can now write their own templates for Tweets
  > Must add an `tweet` string under `announcements` object to `package.json`
  > Variables string as: `<%= variableName %>`

* Possible variables:
  * Package name: `<%= package %>`
  * Version number: `<%= version %>`
  * Package description: `<%= description %>`
  * Package author: `<%= author %>`
  * Homepage link: `<%= homepage%>`