### PR TITLE
tests: move to using snapshot and fix coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+test-results
 
 # nyc test coverage
 .nyc_output

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,9 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   coverageReporters: ["json", "lcov", "text", "clover", "html"],
-  modulePathIgnorePatterns: ["<rootDir>/lib/"]
+  modulePathIgnorePatterns: ["<rootDir>/lib/"],
+  collectCoverageFrom: [
+    "src/**/*.ts",
+    "!src/**/index.ts",
+  ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,6 @@ module.exports = {
   collectCoverageFrom: [
     "src/**/*.ts",
     "!src/**/index.ts",
+    "!src/announce-it-cli.ts"
   ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,6 @@ module.exports = {
   watchPathIgnorePatterns: [
     ".*test-results.*\\.js"
   ],
-  reporters: ["default", "jest-allure", "jest-stare"],
+  reporters: ["default", "jest-stare"],
   testResultsProcessor: "./node_modules/jest-stare"
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,5 +7,10 @@ module.exports = {
     "src/**/*.ts",
     "!src/**/index.ts",
     "!src/announce-it-cli.ts"
-  ]
+  ],
+  watchPathIgnorePatterns: [
+    ".*test-results.*\\.js"
+  ],
+  reporters: ["default", "jest-allure", "jest-stare"],
+  testResultsProcessor: "./node_modules/jest-stare"
 };

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "all-contributors-cli": "^6.2.0",
     "coveralls": "^3.0.3",
     "jest": "^24.5.0",
+    "jest-stare": "^1.13.2",
     "npm-check": "^5.9.0",
     "semantic-release": "^16.0.0-beta.18",
     "semantic-release-cli": "^5.0.0",
@@ -88,5 +89,9 @@
     "lodash": "^4.17.11",
     "manakin": "^0.5.2",
     "twitter-lite": "^0.9.4"
+  },
+  "jest-stare": {
+    "resultDir": "test-results/",
+    "coverageLink": "../coverage/index.html"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "lint:fix": "tslint -c tslint.json --fix src/**/*.ts",
     "lint": "tslint -c tslint.json src/**/*.ts",
     "semantic-release": "semantic-release",
-    "start:dev": "ts-node ./src/announce-it-cli.ts",
+    "start:dev": "ts-node -r dotenv/config ./src/announce-it-cli.ts",
     "start": "node ./lib/announce-it-cli",
-    "test:watch": "jest --watchAll",
+    "test:watch": "jest --watchAll --coverage",
     "test": "jest --coverage"
   },
   "repository": {

--- a/src/__snapshots__/announce-it-cli-utils.test.ts.snap
+++ b/src/__snapshots__/announce-it-cli-utils.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AnnounceItCli areEnvVariablesDefined should reject if at least 1 required environment variable is missing 1`] = `"These Environment variables are required: CONSUMER_KEY CONSUMER_SECRET ACCESS_TOKEN_KEY ACCESS_TOKEN_SECRET"`;
+
+exports[`AnnounceItCli areEnvVariablesDefined should reject if at least 1 required environment variable is missing 2`] = `"These Environment variables are required: CONSUMER_KEY CONSUMER_SECRET ACCESS_TOKEN_KEY ACCESS_TOKEN_SECRET"`;
+
+exports[`AnnounceItCli areEnvVariablesDefined should resolve if all required environment variables exists 1`] = `undefined`;
+
+exports[`AnnounceItCli findRoot should return the project root folder if ran inside npm project 1`] = `"project-root"`;
+
+exports[`AnnounceItCli findRoot should throw error if not inside npm project 1`] = `"couldn't find npm project root: failure (test mock)"`;

--- a/src/__snapshots__/announce-it.test.ts.snap
+++ b/src/__snapshots__/announce-it.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KbAnnounceIt should create instance when given correct parameters 1`] = `
+KbAnnounceIt {
+  "client": Object {
+    "get": [Function],
+    "post": [Function],
+  },
+}
+`;
+
+exports[`KbAnnounceIt should throw error when missing options 1`] = `"ERROR: missing required options"`;
+
+exports[`KbAnnounceIt should throw error when missing options 2`] = `"ERROR: missing required options"`;
+
+exports[`KbAnnounceIt should throw error when missing options 3`] = `"ERROR: missing required options"`;
+
+exports[`KbAnnounceIt should throw error when missing options 4`] = `"ERROR: missing required options"`;
+
+exports[`KbAnnounceIt should throw error when missing options 5`] = `"ERROR: missing required options"`;
+
+exports[`kbAnnounceIt.announceRelease should post to twitter when stable release 1`] = `"test-template"`;
+
+exports[`kbAnnounceIt.announceRelease should post to twitter when unstable release and mentioned in packageDetails 1`] = `"test-template"`;
+
+exports[`kbAnnounceIt.announceRelease should throw an error when unstable release and not mentioned in packageDetails 1`] = `"Not a stable release"`;
+
+exports[`kbAnnounceIt.announceRelease should throw error when twitter get credentials throws an error 1`] = `"Twitter Get Error"`;
+
+exports[`kbAnnounceIt.announceRelease should throw error when twitter post tweet throws an error 1`] = `"Twitter Post Error"`;
+
+exports[`kbAnnounceIt.generateTweet should throw error on missing package details input 1`] = `"The key name is missing from given object"`;
+
+exports[`kbAnnounceIt.generateTweet should throw error on non object input 1`] = `"Expecting Object"`;
+
+exports[`kbAnnounceIt.generateTweet should throw error when using missing variables in template 1`] = `"Using missing variables in tweet template"`;

--- a/src/__snapshots__/read-package-details.test.ts.snap
+++ b/src/__snapshots__/read-package-details.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`readPackageDetails should return the package details 1`] = `
+Object {
+  "announcements": Object {
+    "tweet": "nice!",
+  },
+  "author": "test@test.com",
+  "description": "package description",
+  "homepage": "pizza.com",
+  "name": "package-name",
+  "repository": Object {
+    "type": "",
+    "url": "",
+  },
+  "version": "1.0.0",
+}
+`;
+
+exports[`readPackageDetails should throw error if missing tweet from package.json 1`] = `"no tweet template found. please see the readme for more details"`;
+
+exports[`readPackageDetails should throw error if reading package.json failed 1`] = `"failed reading json file"`;

--- a/src/announce-it-cli-utils.test.ts
+++ b/src/announce-it-cli-utils.test.ts
@@ -1,0 +1,67 @@
+import fs from 'fs-extra';
+import { assign } from 'lodash';
+
+import { AnnounceItCli } from './announce-it-cli-utils';
+import { IPackageDetails } from './read-package-details';
+
+jest.mock('find-root', () => (folder: string) => {
+  if (folder === 'test-failure') {
+    throw new Error('failure (test mock)');
+  }
+
+  return 'project-root';
+});
+
+const packageDetails: IPackageDetails = {
+  name: 'package-name',
+  description: 'package description',
+  version: '1.0.0',
+  author: 'test@test.com',
+  homepage: 'pizza.com',
+  repository: {
+    type: '',
+    url: ''
+  },
+  announcements: {
+    tweet: 'nice!'
+  }
+};
+
+describe('AnnounceItCli', () => {
+  const announceItCli = new AnnounceItCli();
+
+  describe('areEnvVariablesDefined', () => {
+    it('should resolve if all required environment variables exists', () => {
+      return expect(announceItCli.areEnvVariablesDefined({
+        CONSUMER_KEY: 'CONSUMER_KEY',
+        CONSUMER_SECRET: 'CONSUMER_SECRET',
+        ACCESS_TOKEN_KEY: 'ACCESS_TOKEN_KEY',
+        ACCESS_TOKEN_SECRET: 'ACCESS_TOKEN_SECRET'
+      })).resolves.toMatchSnapshot();
+    });
+    it('should reject if at least 1 required environment variable is missing', () => {
+      return expect(announceItCli.areEnvVariablesDefined({
+        CONSUMER_KEY: 'CONSUMER_KEY',
+        CONSUMER_SECRET: 'CONSUMER_SECRET',
+        ACCESS_TOKEN_SECRET: 'ACCESS_TOKEN_SECRET'
+      }))
+        .rejects.toThrowErrorMatchingSnapshot()
+        .then(() => expect(announceItCli.areEnvVariablesDefined({}))
+          .rejects.toThrowErrorMatchingSnapshot());
+    });
+  });
+
+  describe('findRoot', () => {
+    it('should return the project root folder if ran inside npm project', () => {
+      return expect(announceItCli.findRoot('test-folder')).resolves.toMatchSnapshot();
+    });
+    it('should throw error if not inside npm project', () => {
+      return expect(announceItCli.findRoot('test-failure')).rejects.toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe('runAnnounceItCli', () => {
+    it.todo('should run the entire flow on correct input');
+    it.todo('should throw error on incorrect input');
+  });
+});

--- a/src/announce-it-cli-utils.ts
+++ b/src/announce-it-cli-utils.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import findRoot from 'find-root';
+import { every, isString } from 'lodash';
+
+import { KbAnnounceIt } from './announce-it';
+import { readPackageDetails } from './read-package-details';
+
+export class AnnounceItCli {
+  areEnvVariablesDefined(env: NodeJS.ProcessEnv): Promise<void> {
+    const envVariables = [
+      'CONSUMER_KEY',
+      'CONSUMER_SECRET',
+      'ACCESS_TOKEN_KEY',
+      'ACCESS_TOKEN_SECRET'
+    ];
+
+    const areEnvVariablesDefined = every(envVariables, (varName) => {
+      return isString(env[ varName ]);
+    });
+
+    if (!areEnvVariablesDefined) {
+      return Promise.reject(new Error(`These Environment variables are required: ${ envVariables.join(' ') }`));
+    }
+
+    return Promise.resolve();
+  }
+
+  findRoot(folder: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      try {
+        const root = findRoot(folder);
+
+        resolve(root);
+      } catch (err) {
+        reject(new Error(`couldn't find npm project root: ${ err.message || err }`));
+      }
+    });
+  }
+
+  runAnnounceItCli(folder: string, env: NodeJS.ProcessEnv): Promise<string> {
+    return this.findRoot(folder)
+      .then((root) => readPackageDetails(root))
+      .then((packageDetails) => {
+        const announceIt = new KbAnnounceIt({
+          consumerKey: env.CONSUMER_KEY as string,
+          consumerSecret: env.CONSUMER_SECRET as string,
+          accessTokenKey: env.ACCESS_TOKEN_KEY as string,
+          accessTokenSecret: env.ACCESS_TOKEN_SECRET as string
+        });
+
+        return announceIt.announceRelease(packageDetails);
+      });
+  }
+}

--- a/src/announce-it-cli.ts
+++ b/src/announce-it-cli.ts
@@ -1,48 +1,17 @@
 #!/usr/bin/env node
-import dotenv from 'dotenv';
-import findRoot from 'find-root';
-import { every, isString } from 'lodash';
 import manakin from 'manakin';
 
-import { KbAnnounceIt } from './announce-it';
-import { readPackageDetails } from './read-package-details';
+import { AnnounceItCli } from './announce-it-cli-utils';
 
 // add console colors
 // tslint:disable-next-line
 manakin.global;
 
-const env = process.env;
+const announceItCli = new AnnounceItCli();
 
-const envVariables = [
-  'CONSUMER_KEY',
-  'CONSUMER_SECRET',
-  'ACCESS_TOKEN_KEY',
-  'ACCESS_TOKEN_SECRET'
-];
-
-const areEnvVariablesDefined = every(envVariables, (varName) => {
-  return isString(process.env[ varName ]);
-});
-
-if (!areEnvVariablesDefined) {
-
-  console.error('ERROR: These Environemnt variables are required:');
-  console.error(`  ${ envVariables.join(' ') }`);
-  process.exit(1);
-}
-
-dotenv.config();
-const root = findRoot(process.cwd());
-
-const announceIt = new KbAnnounceIt({
-  consumerKey: env.CONSUMER_KEY as string,
-  consumerSecret: env.CONSUMER_SECRET as string,
-  accessTokenKey: env.ACCESS_TOKEN_KEY as string,
-  accessTokenSecret: env.ACCESS_TOKEN_SECRET as string
-});
-
-readPackageDetails(root)
-  .then((packageDetails) => announceIt.announceRelease(packageDetails))
+announceItCli.areEnvVariablesDefined(process.env)
+  .then(() => announceItCli.findRoot(process.cwd()))
+  .then((root) => announceItCli.runAnnounceItCli(root, process.env))
   .catch((error: Error) => {
     console.error('ERROR: Something went wrong');
     console.error(error);

--- a/src/announce-it.test.ts
+++ b/src/announce-it.test.ts
@@ -1,4 +1,5 @@
 import { assign, cloneDeep } from 'lodash';
+
 import { KbAnnounceIt } from './announce-it';
 import { IPackageDetails } from './read-package-details';
 

--- a/src/announce-it.test.ts
+++ b/src/announce-it.test.ts
@@ -29,34 +29,34 @@ describe('KbAnnounceIt', () => {
     expect.assertions(5);
 
     // @ts-ignore
-    expect(() => new KbAnnounceIt()).toThrow(Error);
+    expect(() => new KbAnnounceIt()).toThrowErrorMatchingSnapshot();
 
     // @ts-ignore
     expect(() => new KbAnnounceIt({
       accessTokenSecret: 'TEST',
       consumerKey: 'TEST',
       consumerSecret: 'TEST'
-    })).toThrow(Error);
+    })).toThrowErrorMatchingSnapshot();
 
     // @ts-ignore
     expect(() => new KbAnnounceIt({
       accessTokenKey: 'TEST',
       consumerKey: 'TEST',
       consumerSecret: 'TEST'
-    })).toThrow(Error);
+    })).toThrowErrorMatchingSnapshot();
 
     // @ts-ignore
     expect(() => new KbAnnounceIt({
       accessTokenKey: 'TEST',
       accessTokenSecret: 'TEST',
       consumerSecret: 'TEST'
-    })).toThrow(Error);
+    })).toThrowErrorMatchingSnapshot();
     // @ts-ignore
     expect(() => new KbAnnounceIt({
       accessTokenKey: 'TEST',
       accessTokenSecret: 'TEST',
       consumerKey: 'TEST'
-    })).toThrow(Error);
+    })).toThrowErrorMatchingSnapshot();
 
   });
 
@@ -69,6 +69,7 @@ describe('KbAnnounceIt', () => {
     });
 
     expect(announceIt).toBeDefined();
+    expect(announceIt).toMatchSnapshot();
   });
 });
 
@@ -100,16 +101,14 @@ describe('kbAnnounceIt.announceRelease', () => {
   });
 
   it('should post to twitter when stable release', () => {
-    return announceIt.announceRelease(packageDetails)
-    .then((tweet) => expect(tweet).toMatch('test-template'));
+    return expect(announceIt.announceRelease(packageDetails)).resolves.toMatchSnapshot();
   });
 
   it('should throw an error when unstable release and not mentioned in packageDetails', () => {
     const testPackageDetails = cloneDeep(packageDetails);
     testPackageDetails.version = '0.0.0-next.1';
 
-    return announceIt.announceRelease(testPackageDetails)
-      .catch((tweet) => expect(tweet).toMatch('Not a stable release'));
+    return expect(announceIt.announceRelease(testPackageDetails)).rejects.toThrowErrorMatchingSnapshot();
   });
 
   it('should post to twitter when unstable release and mentioned in packageDetails', () => {
@@ -117,49 +116,73 @@ describe('kbAnnounceIt.announceRelease', () => {
     testPackageDetails.version = '0.0.0-next.1';
     testPackageDetails.announcements.includeUnstable = true;
 
-    return announceIt.announceRelease(testPackageDetails)
-      .then((tweet) => expect(tweet).toMatch('test-template'));
-  });
-
-  it('should throw error on missing package details input', () => {
-    const testPackageDetails: any = assign({}, packageDetails);
-    testPackageDetails.name = null;
-
-    expect(() => announceIt.announceRelease(testPackageDetails)).toThrow(Error);
+    return expect(announceIt.announceRelease(testPackageDetails)).resolves.toMatchSnapshot();
   });
 
   it('should throw error when twitter get credentials throws an error', async () => {
-    expect.assertions(1);
+    twitterMocks.reset({ get: (...args: any) => Promise.reject(new Error('Twitter Get Error')) });
 
-    twitterMocks.reset({ get: (...args: any) => Promise.reject('Twitter Get Error') });
-
-    try {
-      await announceIt.announceRelease(packageDetails);
-    } catch (e) {
-      // TODO: FEATURE: create a basic KbError class
-      expect(e).toMatch('Twitter Get Error');
-    }
+    // TODO: FEATURE: create a basic KbError class
+    return expect(announceIt.announceRelease(packageDetails)).rejects
+      .toThrowErrorMatchingSnapshot();
   });
 
   it('should throw error when twitter post tweet throws an error', async () => {
     expect.assertions(1);
 
     twitterMocks.reset({
-      post: (...args: any) => Promise.reject('Twitter Post Error'),
+      post: (...args: any) => Promise.reject(new Error('Twitter Post Error')),
       get: (...args: any) => Promise.resolve()
-     });
+    });
 
-    try {
-      await announceIt.announceRelease(packageDetails);
-    } catch (e) {
-      expect(e).toMatch('Twitter Post Error');
+    return expect(announceIt.announceRelease(packageDetails)).rejects
+      .toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('kbAnnounceIt.generateTweet', () => {
+  const packageDetails: IPackageDetails = {
+    name: 'test-repo',
+    description: 'test-description',
+    author: 'test-author',
+    homepage: 'test-homepage',
+    repository: {
+      type: 'test-repo-type',
+      url: 'test-repo-url'
+    },
+    version: '0.0.0',
+    announcements: {
+      tweet: 'test-template'
     }
+  };
+
+  let announceIt: KbAnnounceIt;
+
+  beforeEach(() => {
+    announceIt = new KbAnnounceIt({
+      accessTokenKey: 'TEST',
+      accessTokenSecret: 'TEST',
+      consumerKey: 'TEST',
+      consumerSecret: 'TEST'
+    });
+  });
+
+  it('should throw error on non object input', () => {
+    // @ts-ignore
+    expect(() => announceIt.generateTweet()).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should throw error on missing package details input', () => {
+    const testPackageDetails: any = assign({}, packageDetails);
+    testPackageDetails.name = null;
+
+    expect(() => announceIt.generateTweet(testPackageDetails)).toThrowErrorMatchingSnapshot();
   });
 
   it('should throw error when using missing variables in template', async () => {
     const testPackageDetails = packageDetails;
     testPackageDetails.announcements.tweet = 'This should <%= blow %> an error';
-    expect(() => announceIt.generateTweet(packageDetails)).toThrow(Error);
+    expect(() => announceIt.generateTweet(packageDetails)).toThrowErrorMatchingSnapshot();
 
   });
 });

--- a/src/announce-it.ts
+++ b/src/announce-it.ts
@@ -31,12 +31,12 @@ export class KbAnnounceIt {
     });
   }
 
-  announceRelease(packageDetails: IPackageDetails): Promise<any> {
+  announceRelease(packageDetails: IPackageDetails): Promise<string> {
     if (
       !packageDetails.announcements.includeUnstable &&
       !packageDetails.version.match(/^(\d+\.)+\d+$/)
-      ) {
-        return Promise.reject('Not a stable release');
+    ) {
+      return Promise.reject(new Error('Not a stable release'));
     }
 
     const tweet = this.generateTweet(packageDetails);
@@ -44,15 +44,13 @@ export class KbAnnounceIt {
     return this.client
       .get('account/verify_credentials')
       .then(() => this.client.post('statuses/update', { status: tweet }))
-      .then(() => {
-        console.log('Tweeted successfully:', tweet);
-        return tweet;
-      });
+      .then(() => tweet);
   }
 
   generateTweet(packageDetails: IPackageDetails): string {
-    const tweetTemplate = template(packageDetails.announcements.tweet);
     this.ensureKeyAttributes(packageDetails);
+
+    const tweetTemplate = template(packageDetails.announcements.tweet);
     let tweet: string;
     try {
       tweet = tweetTemplate({
@@ -71,7 +69,7 @@ export class KbAnnounceIt {
   }
 
   private ensureKeyAttributes(packageDetails: Partial<IPackageDetails>): void {
-    const requiredKeys = ['name', 'version', 'announcements.tweet'];
+    const requiredKeys = [ 'name', 'version', 'announcements.tweet' ];
 
     if (!isObject(packageDetails)) {
       throw new Error('Expecting Object');
@@ -79,7 +77,7 @@ export class KbAnnounceIt {
 
     forEach(requiredKeys, (key) => {
       if (isNil(get(packageDetails, key))) {
-        throw new Error(`The key ${key} is missing from given object`);
+        throw new Error(`The key ${ key } is missing from given object`);
       }
     });
   }

--- a/src/read-package-details.test.ts
+++ b/src/read-package-details.test.ts
@@ -1,6 +1,7 @@
-import { IPackageDetails, readPackageDetails } from './read-package-details';
 import fs from 'fs-extra';
 import { assign } from 'lodash';
+
+import { IPackageDetails, readPackageDetails } from './read-package-details';
 
 const packageDetails: IPackageDetails = {
   name: 'package-name',

--- a/src/read-package-details.test.ts
+++ b/src/read-package-details.test.ts
@@ -1,0 +1,43 @@
+import { IPackageDetails, readPackageDetails } from './read-package-details';
+import fs from 'fs-extra';
+import { assign } from 'lodash';
+
+const packageDetails: IPackageDetails = {
+  name: 'package-name',
+  description: 'package description',
+  version: '1.0.0',
+  author: 'test@test.com',
+  homepage: 'pizza.com',
+  repository: {
+    type: '',
+    url: ''
+  },
+  announcements: {
+    tweet: 'nice!'
+  }
+};
+
+jest.mock('fs-extra');
+
+describe('readPackageDetails', () => {
+  it('should return the package details', () => {
+    // @ts-ignore
+    fs.readJson.mockResolvedValue(packageDetails);
+    return expect(readPackageDetails('rootFolder')).resolves.toMatchSnapshot();
+  });
+
+  it('should throw error if reading package.json failed', () => {
+    // @ts-ignore
+    fs.readJson.mockRejectedValue(new Error('failed reading json file'));
+    return expect(readPackageDetails('rootFolder')).rejects.toThrowErrorMatchingSnapshot();
+  });
+
+  it('should throw error if missing tweet from package.json', () => {
+    const missingDetails: Partial<IPackageDetails> = assign({}, packageDetails);
+    missingDetails.announcements = undefined;
+    // @ts-ignore
+    fs.readJson.mockResolvedValue(missingDetails);
+
+    return expect(readPackageDetails('rootFolder')).rejects.toThrowErrorMatchingSnapshot();
+  });
+});


### PR DESCRIPTION
resolves #35 

this PR includes jest snapshot files. These should be submitted as part of the code and the tests run against them. any change in checked outputs will fail the tests, and will require the user to regenerate the snapshots and submit them to make sure that change is intentional.

We should examine if this is a good path to take. there are some bad reviews about snapshot testing (that it makes tests unclear) but this thing is pretty simple and I think the snapshots are pretty good structure wise for this case.

**We should review the snapshots as well as the tests and the code**