### PR TITLE
chore: fix readme typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/Kibibit/announce-it#readme",
   "announcements": {
-    "tweet": "We have an announcement!\n<%= package %> <%= version %> in now live!\n\nGo check it out: <%= npmpage %>"
+    "tweet": "We have an announcement!\n<%= package %> <%= version %> is now live!\n\nGo check it out: <%= npmpage %>"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
in now live -> is now live